### PR TITLE
Fix attempt to reference invalid memory when calling Discord::with_cr…

### DIFF
--- a/discord_game_sdk/src/discord.rs
+++ b/discord_game_sdk/src/discord.rs
@@ -62,7 +62,9 @@ impl<E> Drop for Discord<'_, E> {
     fn drop(&mut self) {
         unsafe {
             let core = (*self.0).core;
-            (*core).destroy.unwrap()(core);
+            if !core.is_null() {
+                (*core).destroy.unwrap()(core);
+            }
 
             drop(Box::from_raw(self.0));
         }


### PR DESCRIPTION
…eate_flags with the NoRequireDiscord flag when discord is not running.

This is because core is null if discord is not running.